### PR TITLE
fix: retrieve user list after deleting user

### DIFF
--- a/src/components/auth/SignUp.jsx
+++ b/src/components/auth/SignUp.jsx
@@ -81,11 +81,11 @@ export default function Signup() {
            
             console.log("User successfully registered")
             // Show success message
-            setSuccessMessage("User successfully registered. Please login on home screen.");
+            setSuccessMessage("User successfully registered. Please login on home screen. Going back home...");
             // Redirect user back to home after 3 seconds
             setTimeout(() => {
                 navigate("/"); // Navigate back to home page
-            }, 3000); // Wait 3 seconds
+            }, 2000); // Wait 3 seconds
             
 
             // Catch response:

--- a/src/components/users/UserList.jsx
+++ b/src/components/users/UserList.jsx
@@ -33,7 +33,9 @@ export default function UserList({ users, getUsers }) {
                 throw new Error("Access token not found. Please login.")
             }
             await axiosInstance.delete(`/users/${userId}`)
+            
             navigate('/users')
+            getUsers()
             // Catch response:
         } catch (error) {
             console.error("Problem deleting user", error.message)


### PR DESCRIPTION
User is now appears to be removed from the user list after pressing the '- Delete' button on /users page (without a refresh). Previously the user would be deleted from the backend, but a refresh was required on the frontend to see the updated list.